### PR TITLE
[#170579231] Remove hasOne association between user and organization registration request

### DIFF
--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -103,10 +103,6 @@ export function createAssociations(): void {
     as: "organizationRegistrationRequests",
     foreignKey: { name: "email", field: "userEmail" }
   });
-  User.hasOne(Request.scope(RequestScope.ORGANIZATION_REGISTRATION), {
-    as: "organizationRegistrationRequest",
-    foreignKey: { name: "email", field: "userEmail" }
-  });
   User.hasMany(Request.scope(RequestScope.USER_DELEGATION), {
     as: "delegationRequests",
     foreignKey: { name: "email", field: "userEmail" }


### PR DESCRIPTION
This PR aims to remove the unnecessary `hasOne` association between `User` and `OrganizationRegistrationRequest`.