### PR TITLE
[#170671935] Rename action in specs: SEND-EMAIL -> SEND_REGISTRATION_REQUEST_EMAIL_TO_ORG

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -464,14 +464,14 @@ components:
         type:
           type: string
           x-extensible-enum:
-            - "SEND-EMAIL"
+            - "SEND_REGISTRATION_REQUEST_EMAIL_TO_ORG"
       required:
         - ids
         - type
       example:
         {
           items: [ 1, 2 ],
-          type: "SEND-EMAIL"
+          type: "SEND_REGISTRATION_REQUEST_EMAIL_TO_ORG"
         }
     FoundAdministration:
       oneOf:


### PR DESCRIPTION
This PR aims to rename the action `SEND-EMAIL` into `SEND_REGISTRATION_REQUEST_EMAIL_TO_ORG` in order to make it more explicit.